### PR TITLE
Add toolchain support for `linux-aarch64` host platform

### DIFF
--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -98,7 +98,10 @@ llvm_toolchain(
         "": ["-fsanitize-link-c++-runtime"],
     },
     linux_x86_64_sysroot = "@gcc_12_toolchain_files//x86_64-buildroot-linux-gnu/sysroot",
-    llvm_version = "16.0.4",
+    llvm_versions = {
+        "": "16.0.4",
+        "linux-aarch64": "16.0.3",
+    },
 )
 
 # register llvm first, it has better error messages

--- a/toolchain/BUILD.bazel
+++ b/toolchain/BUILD.bazel
@@ -22,11 +22,28 @@ alias(
     actual = ":gcc12",
 )
 
+config_setting(
+    name = "linux_aarch64",
+    constraint_values = [
+        "@platforms//os:linux",
+        "@platforms//cpu:aarch64",
+    ],
+)
+
+config_setting(
+    name = "linux_x86_64",
+    constraint_values = [
+        "@platforms//os:linux",
+        "@platforms//cpu:x86_64",
+    ],
+)
+
 alias(
     name = "clang16",
     actual = select({
         "@platforms//os:macos": "@llvm_16_toolchain//:cc-toolchain-aarch64-darwin",
-        "//conditions:default": "@llvm_16_toolchain//:cc-toolchain-x86_64-linux",
+        ":linux_aarch64": "@llvm_16_toolchain//:cc-toolchain-aarch64-linux",
+        ":linux_x86_64": "@llvm_16_toolchain//:cc-toolchain-x86_64-linux",
     }),
 )
 
@@ -36,13 +53,14 @@ alias(
 )
 
 # Doesn't work on MacOS: https://github.com/grailbio/bazel-toolchain/issues/192
-config_setting(
-    name = "linux",
-    constraint_values = ["@platforms//os:linux"],
-)
-
 linux_only = select({
-    "linux": [],
+    ":linux_aarch64": [],
+    ":linux_x86_64": [],
+    "//conditions:default": ["@platforms//:incompatible"],
+})
+
+linux_x86_64_only = select({
+    ":linux_x86_64": [],
     "//conditions:default": ["@platforms//:incompatible"],
 })
 
@@ -51,7 +69,7 @@ cc_binary(
     srcs = ["asan_feature_available.cpp"],
     copts = ["-O0"],
     features = ["asan"],
-    target_compatible_with = linux_only,
+    target_compatible_with = linux_x86_64_only,
 )
 
 sh_test(

--- a/tools/llvm_toolchain.bzl
+++ b/tools/llvm_toolchain.bzl
@@ -114,7 +114,8 @@ def llvm_toolchain(linux_x86_64_sysroot = "", **kwargs):
 
     _llvm_toolchain_files(
         name = kwargs["name"] + "_files",
-        llvm_version = kwargs["llvm_version"],
+        llvm_version = kwargs.get("llvm_version", None),
+        llvm_versions = kwargs.get("llvm_versions", None),
     )
 
     _patch_dynamic_linker(
@@ -168,7 +169,13 @@ def llvm_toolchain(linux_x86_64_sysroot = "", **kwargs):
         ],
     )
 
-    major_version = kwargs["llvm_version"].split(".")[0]
+    if "llvm_version" in kwargs:
+        version = kwargs["llvm_version"]
+    else:
+        versions = kwargs["llvm_versions"]
+        version = versions.get("linux-x86_64", None) or versions[""]
+    major_version = version.split(".")[0]
+
     kwargs["cxx_builtin_include_directories"] = _extend_linux_x86_64_key(
         kwargs.get("cxx_builtin_include_directories", {"": []}),
         [


### PR DESCRIPTION
Download hermetic LLVM toolchain when host is linux-aarch64. This
platform uses 16.03 as the 16.04 release is not available.

Change-Id: Ic34b0245183901c327340d2848e0202b5153cc84