### PR TITLE
Add VESC example program

### DIFF
--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -1,0 +1,7 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary")
+
+cc_binary(
+    name = "vesc_cmd",
+    srcs = ["vesc_cmd.cpp"],
+    deps = ["//third_party/vesc_uart"],
+)

--- a/examples/vesc_cmd.cpp
+++ b/examples/vesc_cmd.cpp
@@ -1,0 +1,8 @@
+#include "third_party/vesc_uart/VescUart.h"
+
+auto main() -> int
+{
+  ::VescUartSetCurrent(1.0F);
+
+  return 0;
+}

--- a/test/BUILD.bazel
+++ b/test/BUILD.bazel
@@ -1,18 +1,10 @@
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_test")
 
-# With GCC and tsan:
-# error: 'atomic_thread_fence' is not supported with '-fsanitize=thread' [-Werror=tsan]
-config_setting(
-    name = "gcc_tsan",
-    flag_values = {"@bazel_tools//tools/cpp:compiler": "gcc"},
-    values = {"features": "tsan"},
-)
-
 cc_binary(
     name = "serial_test",
     srcs = ["serial_test.cpp"],
     target_compatible_with = select({
-        ":gcc_tsan": ["@platforms//:incompatible"],
+        "//toolchain:gcc_tsan": ["@platforms//:incompatible"],
         "//conditions:default": [],
     }),
     deps = [

--- a/third_party/vesc_uart/BUILD.bazel
+++ b/third_party/vesc_uart/BUILD.bazel
@@ -26,7 +26,8 @@ cc_library(
         "src/includes",
     ],
     visibility = ["//:__subpackages__"],
-    deps = [
-        "//uart_abstraction:fake",
-    ],
+    deps = select({
+        "//toolchain:linux_aarch64": ["//uart_abstraction:rpi"],
+        "//conditions:default": ["//uart_abstraction:fake"],
+    }),
 )

--- a/third_party/vesc_uart/src/compatability/WProgram.h
+++ b/third_party/vesc_uart/src/compatability/WProgram.h
@@ -17,7 +17,7 @@ using boolean = bool;
 #include <cassert>
 #include <chrono>
 #include <thread>
-auto delay(int milliseconds) -> void
+inline auto delay(int milliseconds) -> void
 {
   assert((milliseconds >= 0) && "A negative sleep duration requested");
 

--- a/toolchain/BUILD.bazel
+++ b/toolchain/BUILD.bazel
@@ -38,6 +38,14 @@ config_setting(
     ],
 )
 
+# With GCC and tsan:
+# error: 'atomic_thread_fence' is not supported with '-fsanitize=thread' [-Werror=tsan]
+config_setting(
+    name = "gcc_tsan",
+    flag_values = {"@bazel_tools//tools/cpp:compiler": "gcc"},
+    values = {"features": "tsan"},
+)
+
 alias(
     name = "clang16",
     actual = select({

--- a/uart_abstraction/BUILD.bazel
+++ b/uart_abstraction/BUILD.bazel
@@ -8,3 +8,17 @@ cc_library(
     hdrs = ["HardwareSerial.hpp"],
     visibility = ["//:__subpackages__"],
 )
+
+cc_library(
+    name = "rpi",
+    srcs = [
+        "rpi/HardwareSerial.cpp",
+    ],
+    hdrs = ["HardwareSerial.hpp"],
+    target_compatible_with = select({
+        "//toolchain:gcc_tsan": ["@platforms//:incompatible"],
+        "//conditions:default": [],
+    }),
+    visibility = ["//:__subpackages__"],
+    deps = ["@asio"],
+)

--- a/uart_abstraction/HardwareSerial.hpp
+++ b/uart_abstraction/HardwareSerial.hpp
@@ -7,6 +7,8 @@
 
 struct HardwareSerial
 {
+  HardwareSerial(const char* dev);
+
   [[nodiscard]]
   auto available() const -> bool;
 

--- a/uart_abstraction/fake/HardwareSerial.cpp
+++ b/uart_abstraction/fake/HardwareSerial.cpp
@@ -1,5 +1,7 @@
 #include "uart_abstraction/HardwareSerial.hpp"
 
+HardwareSerial::HardwareSerial(const char*) {}
+
 // NOLINTNEXTLINE(readability-convert-member-functions-to-static)
 auto HardwareSerial::available() const -> bool
 {
@@ -18,4 +20,4 @@ auto HardwareSerial::write(
 {}
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
-HardwareSerial Serial;
+HardwareSerial Serial{""};

--- a/uart_abstraction/rpi/HardwareSerial.cpp
+++ b/uart_abstraction/rpi/HardwareSerial.cpp
@@ -1,0 +1,75 @@
+#include "uart_abstraction/HardwareSerial.hpp"
+
+#include <asio.hpp>
+#include <cassert>
+#include <optional>
+#include <stdexcept>
+#include <sys/select.h>
+
+// NOLINTBEGIN(cppcoreguidelines-avoid-non-const-global-variables)
+
+namespace {
+auto ctx = asio::io_context{};
+auto underlying = std::optional<asio::serial_port>{};
+}  // namespace
+
+HardwareSerial Serial{"/dev/ttyS0"};
+
+// NOLINTEND(cppcoreguidelines-avoid-non-const-global-variables)
+
+HardwareSerial::HardwareSerial(const char* device)
+{
+  underlying.emplace(ctx, device);
+
+  using opt = asio::serial_port_base;
+
+  // NOLINTBEGIN(readability-magic-numbers)
+  underlying->set_option(opt::baud_rate{115200});
+  underlying->set_option(opt::character_size{8});
+  underlying->set_option(opt::parity{opt::parity::none});
+  underlying->set_option(opt::stop_bits{opt::stop_bits::one});
+  // NOLINTEND(readability-magic-numbers)
+
+  assert(underlying->is_open() and "underlying device not open");
+}
+
+// NOLINTNEXTLINE(readability-convert-member-functions-to-static)
+auto HardwareSerial::available() const -> bool
+{
+  // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
+  auto native = underlying->native_handle();
+
+  ::fd_set rfds;
+  auto tv = ::timeval{{}, {}};
+
+  FD_ZERO(&rfds);
+  FD_SET(native, &rfds);
+
+  const auto retval = ::select(1, &rfds, NULL, NULL, &tv);
+  assert(retval >= 0 and "error in checking serial availability");
+
+  return retval > 0;
+}
+
+// NOLINTNEXTLINE(readability-convert-member-functions-to-static)
+auto HardwareSerial::read() const -> std::uint8_t
+{
+  auto c = char{};
+
+  for (auto n = std::size_t{}; n != 1;) {
+    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
+    n = underlying->read_some(asio::buffer(&c, 1));
+    assert(n <= 1 and "read more than 1 byte");
+  }
+
+  return static_cast<std::uint8_t>(c);
+}
+
+// NOLINTNEXTLINE(readability-convert-member-functions-to-static)
+auto HardwareSerial::write(std::uint8_t* buffer, std::size_t size) const -> void
+{
+  for (auto buf = asio::buffer(buffer, size); buf.size() != 0;) {
+    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
+    buf += underlying->write_some(buf);
+  }
+}


### PR DESCRIPTION
Define example program `//examples:vesc_cmd` that sends a 1.0F current
reference to a motor controller connected to `/dev/ttyS0`. This program
is implicitly constrained to the Raspberry Pi via the dependencies of
`//third_party/vesc_uart`.

Change-Id: I8cbf7d674e1f47d2e0ebce7f795a1b5d353f918e