### PR TITLE
Add example to build and link against `libi2c`

### DIFF
--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -29,10 +29,35 @@ load("//tools:host_system_libraries.bzl", "host_system_libraries")
 
 host_system_libraries(
     name = "host_system_libraries",
-    find = ["libtinfo.so.5"],
+    find = [
+        "libi2c.so.0",
+        "libtinfo.so.5",
+    ],
 )
 
 load("@host_system_libraries//:defs.bzl", "HOST_SYSTEM_LIBRARIES")
+
+new_local_repository(
+    name = "linux-x86_64_usr_i2c",
+    build_file_content = """
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+cc_library(
+    name = "i2c",
+    srcs = ["lib/x86_64-linux-gnu/libi2c.so"],
+)
+
+cc_library(
+    name = "linux-x86_64_usr_i2c",
+    hdrs = ["include/i2c/smbus.h"],
+    includes = ["include"],
+    linkopts = ["-li2c"],
+    visibility = ["//visibility:public"],
+    deps = [":i2c"],
+)
+""",
+    path = "/usr",
+)
 
 # Note: not correct on MacOS.
 LLVM_COLOR_FLAGS = ["-fdiagnostics-color=always" if "libinfo.so.5" in HOST_SYSTEM_LIBRARIES else ""]

--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -1,7 +1,23 @@
 load("@rules_cc//cc:defs.bzl", "cc_binary")
+load("@host_system_libraries//:defs.bzl", "HOST_SYSTEM_LIBRARIES")
 
 cc_binary(
     name = "vesc_cmd",
     srcs = ["vesc_cmd.cpp"],
     deps = ["//third_party/vesc_uart"],
+)
+
+has_libi2c = [] if ("libi2c.so.0" in HOST_SYSTEM_LIBRARIES) else ["@platforms//:incompatible"]
+
+cc_binary(
+    name = "i2c",
+    srcs = ["i2c.cpp"],
+    target_compatible_with = has_libi2c,
+    deps = [
+        "@fmt",
+    ] + select({
+        # x86-64 uses a hermetic sysroot and system libraries need to be explicitly specified
+        "//toolchain:linux_x86_64": ["@linux-x86_64_usr_i2c"],
+        "//conditions:default": [],
+    }),
 )

--- a/examples/i2c.cpp
+++ b/examples/i2c.cpp
@@ -1,0 +1,40 @@
+extern "C" {
+#include <i2c/smbus.h>
+#include <linux/i2c-dev.h>
+}
+
+#include <cassert>
+#include <fcntl.h>
+#include <fmt/core.h>
+#include <sys/ioctl.h>
+
+// https://docs.kernel.org/i2c/dev-interface.html
+
+auto main(int argc, char** argv) -> int
+{
+  assert(
+      false and
+      "This example is only intended to test building and linking "
+      "with libi2c");
+
+  if (argc < 2) {
+    fmt::print("./i2c <device>");
+    return 1;
+  }
+
+  const auto fd = ::open(argv[1], O_RDWR);
+  if (fd < 0) {
+    fmt::print("error in opening device");
+    return 1;
+  }
+
+  constexpr auto addr = int{0x40}; /* The I2C address */
+
+  if (::ioctl(fd, I2C_SLAVE, addr) < 0) {
+    fmt::print("error specifying i2c device address");
+    return 1;
+  }
+
+  ::i2c_smbus_read_block_data(fd, 0, nullptr);
+  return 0;
+}


### PR DESCRIPTION
Define `//examples:i2c` which intended to test building a program that
links against `libi2c`. This example is marked incompatible if `libi2c`
is not detected on the host platform during workspace configuration.

Linux x86-64 is configured to use hermetic toolchains with a hermetic
sysroot. As a result, system libraries need to be explicitly specified
as `/usr/include` and `/usr/lib` are not searched for headers and
libraries. When building for this host, `libi2c` is explicitly defined
to allow use.

Change-Id: I232a877e7e7bb6afbbc5a956e5eaba75488e190a