### PR TITLE
Fix linking against `libi2c-dev` on linux-aarch64

### DIFF
--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -38,7 +38,7 @@ host_system_libraries(
 load("@host_system_libraries//:defs.bzl", "HOST_SYSTEM_LIBRARIES")
 
 new_local_repository(
-    name = "linux-x86_64_usr_i2c",
+    name = "linux_x86-64_usr_i2c",
     build_file_content = """
 load("@rules_cc//cc:defs.bzl", "cc_library")
 
@@ -48,10 +48,9 @@ cc_library(
 )
 
 cc_library(
-    name = "linux-x86_64_usr_i2c",
+    name = "linux_x86-64_usr_i2c",
     hdrs = ["include/i2c/smbus.h"],
     includes = ["include"],
-    linkopts = ["-li2c"],
     visibility = ["//visibility:public"],
     deps = [":i2c"],
 )

--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -1,5 +1,4 @@
 load("@rules_cc//cc:defs.bzl", "cc_binary")
-load("@host_system_libraries//:defs.bzl", "HOST_SYSTEM_LIBRARIES")
 
 cc_binary(
     name = "vesc_cmd",
@@ -7,17 +6,11 @@ cc_binary(
     deps = ["//third_party/vesc_uart"],
 )
 
-has_libi2c = [] if ("libi2c.so.0" in HOST_SYSTEM_LIBRARIES) else ["@platforms//:incompatible"]
-
 cc_binary(
     name = "i2c",
     srcs = ["i2c.cpp"],
-    target_compatible_with = has_libi2c,
     deps = [
+        "//system:libi2c-dev",
         "@fmt",
-    ] + select({
-        # x86-64 uses a hermetic sysroot and system libraries need to be explicitly specified
-        "//toolchain:linux_x86_64": ["@linux-x86_64_usr_i2c"],
-        "//conditions:default": [],
-    }),
+    ],
 )

--- a/system/BUILD.bazel
+++ b/system/BUILD.bazel
@@ -1,0 +1,16 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
+load("@host_system_libraries//:defs.bzl", "HOST_SYSTEM_LIBRARIES")
+
+has_libi2c = [] if ("libi2c.so.0" in HOST_SYSTEM_LIBRARIES) else ["@platforms//:incompatible"]
+
+cc_library(
+    name = "libi2c-dev",
+    linkopts = ["-li2c"],
+    target_compatible_with = has_libi2c,
+    visibility = ["//:__subpackages__"],
+    deps = select({
+        # x86-64 uses a hermetic sysroot and system libraries need to be explicitly specified
+        "//toolchain:linux_x86_64": ["@linux_x86-64_usr_i2c"],
+        "//conditions:default": [],
+    }),
+)


### PR DESCRIPTION
Change-Id: I9f3b586c500db71e178b8d1c3185a5c4c9bbf1eb